### PR TITLE
 支持在Windows系统上AndroidManifest.xml包含中文

### DIFF
--- a/buildSrc/src/main/groovy/me/ele/amigo/AmigoPlugin.groovy
+++ b/buildSrc/src/main/groovy/me/ele/amigo/AmigoPlugin.groovy
@@ -96,7 +96,7 @@ class AmigoPlugin implements Plugin<Project> {
 
                         Node hackAppNode = new Node(appNode, "activity")
                         hackAppNode.attributes().put("android:name", applicationName)
-                        manifestFile.text = XmlUtil.serialize(node)
+                        manifestFile.bytes = XmlUtil.serialize(node).getBytes("UTF-8");
 
                         generateCodeTask = project.tasks.create(
                                 name: "generate${variant.name.capitalize()}ApplicationInfo",


### PR DESCRIPTION
修复 在windows系统上AndroidManifest.xml有中文则无法使用的问题