### PR TITLE
add autoDisableInInstantRunMode to auto disable in instant run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ android {
 //you can define this extension in your mybuild.gradle as to distinguish debug & release build
 amigo {
     disable false //default false
+    autoDisableInInstantRunMode true // default false
 }
 
 ```
@@ -136,7 +137,7 @@ There are two gradle tasks provided in the app/build.gradle, `:app:runHost`, `:a
         Cursor cursor = getContentResolver().query(Uri.parse("content://" + targetPackageName + ".provider/student?id=0"), null, null, null, null);
         ```
 
- -  Instant Run conflicts with Amigo, so disable Instant Run when used with amigo
+ -  Instant Run conflicts with Amigo, so disable Instant Run when used with amigo(Or use `autoDisableInInstantRunMode` to auto disable amigo in instant run mode)
 
  -  Amigo doesn't support Honeycomb `3.0`
     * Android 3.0 is a version with full of bugs, & Google has closed Android 3.0 Honeycomb.

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,7 @@ android {
 //你可以把这个定义在mybuild.gradle，以区分debug & release打包
 amigo {
     disable false //默认 false
+    autoDisableInInstantRunMode true // 默认 true
 }
 
 ```
@@ -142,7 +143,7 @@ Gradle插件会自动选择正确的库版本,在开发过程中,我们会使用
         Cursor cursor = getContentResolver().query(Uri.parse("content://" + targetPackageName + ".provider/student?id=0"), null, null, null, null);
         ```
 
-- 不支持和Instant Run同时使用
+- 不支持和Instant Run同时使用（或者使用`autoDisableInInstantRunMode`来自动停止使用amigo）
 
 -  Amigo 不支持 Honeycomb `3.0`
     * Android 3.0 是一个满是bug的版本, & 并且Google已经关闭这个版本.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,7 @@ dependencies {
 
 amigo {
     disable false
+    autoDisableInInstantRunMode true
 }
 
 

--- a/buildSrc/src/main/groovy/me/ele/amigo/AmigoExtension.groovy
+++ b/buildSrc/src/main/groovy/me/ele/amigo/AmigoExtension.groovy
@@ -3,4 +3,5 @@ package me.ele.amigo;
 
 public class AmigoExtension {
     boolean disable;
+    boolean autoDisableInInstantRunMode;
 }

--- a/buildSrc/src/main/groovy/me/ele/amigo/AmigoPlugin.groovy
+++ b/buildSrc/src/main/groovy/me/ele/amigo/AmigoPlugin.groovy
@@ -5,8 +5,6 @@ import com.android.build.gradle.api.BaseVariantOutput
 import groovy.io.FileType
 import groovy.xml.QName
 import groovy.xml.XmlUtil
-import org.apache.tools.ant.types.RegularExpression
-import org.apache.tools.ant.util.regexp.RegexpUtil
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -60,7 +58,12 @@ class AmigoPlugin implements Plugin<Project> {
                 println 'check instant run'
                 Task instantRunTask = project.tasks.findByName("transformClassesWithInstantRunVerifierFor${variant.name.capitalize()}")
                 if (instantRunTask) {
-                    throw RuntimeException("Sorry, instant run conflicts with Amigo, so please disable Instant Run")
+                    if (ext.autoDisableInInstantRunMode) {
+                        println 'amigo is auto disable in instant run mode.'
+                        return
+                    } else {
+                        throw RuntimeException("Sorry, instant run conflicts with Amigo, so please disable Instant Run")
+                    }
                 }
 
                 Task prepareDependencyTask = project.tasks.findByName("prepare${variant.name.capitalize()}Dependencies")


### PR DESCRIPTION
We often develop in instant run mode, and release application through `gradle aR`, so we can auto disable in instant run mode without change `disable` in amigo.